### PR TITLE
ReplaceTimestamps - adds support for editing a message

### DIFF
--- a/ReplaceTimestamps/components/settings.jsx
+++ b/ReplaceTimestamps/components/settings.jsx
@@ -4,8 +4,9 @@ import React from "react";
 import Settings from "../modules/settings";
 import SettingsItems from "../modules/settings.json";
 
-const { SettingItem } = Components;
+const { SettingItem, SwitchInput } = Components;
 const Select = Webpack.getByStrings(".selectPositionTop]:\"top\"===", { searchExports: true });
+const useStateFromStores = Webpack.getByStrings("useStateFromStores", { searchExports: true });
 
 function DropdownItem(props) {
     return (
@@ -21,11 +22,30 @@ function DropdownItem(props) {
     );
 }
 
+function SwitchItem(props) {
+    const value = useStateFromStores([Settings], () => Settings.get(props.id, props.value));
+    return (
+        <SettingItem
+            {...props}
+            inline={true}
+        >
+            <SwitchInput
+                value={value}
+                onChange={v => {
+                    Settings.set(props.id, v);
+                }}
+            />
+        </SettingItem>
+    );
+}
+
 function renderSettings(items) {
     return items.map(item => {
         switch (item.type) {
             case "dropdown":
                 return <DropdownItem {...item} />;
+            case "switch":
+                return <SwitchItem {...item} />;
             default:
                 return null;
         }

--- a/ReplaceTimestamps/index.jsx
+++ b/ReplaceTimestamps/index.jsx
@@ -13,42 +13,48 @@ export let timeRegexMatch, dateRegexMatch, relativeRegexMatch;
 export default class ReplaceTimestamps {
     start() {
         showChangelog(manifest);
-        this.patchSendMessage();
+        this.patchMessageActions();
         Styles.load();
     }
-
     stop() {
         Patcher.unpatchAll();
         Styles.unload();
     }
 
-    patchSendMessage() {
-        const MessageActions = Webpack.getByKeys("sendMessage");
+    patchMessageActions() {
+        const MessageActions = Webpack.getByKeys("sendMessage", "editMessage");
 
+        const timeRegex = /(?<!\d)\d{1,2}:\d{2}(?!\d)(am|pm)?/gi;
+        exports.timeRegexMatch = /((?<!\d)\d{1,2}:\d{2}(?!\d))(am|pm)?/i;
+
+        const dateFormat = Settings.get("dateFormat", "dd.MM.yyyy")
+            .replace(/[.\/]/g, "[./]")
+            .replace("dd", "(\\d{2})")
+            .replace("MM", "(\\d{2})")
+            .replace("yyyy", "(\\d{4})");
+
+        const dateRegex = new RegExp(`${dateFormat}`, "gi");
+        exports.dateRegexMatch = new RegExp(`${dateFormat}`, "i");
+
+        const TimeDateRegex = new RegExp(`(${timeRegex.source})\\s+${dateRegex.source}`, "gi");
+        const DateRegexTime = new RegExp(`${dateRegex.source}\\s+(${timeRegex.source})`, "gi");
+
+        const relativeRegex = /\b(?:in\s+(\d+)([smhdw]|mo|y)|(\d+)([smhdw]|mo|y)\s+ago)\b/gi;
+        exports.relativeRegexMatch = /\b(?:in\s+(\d+)([smhdw]|mo|y)|(\d+)([smhdw]|mo|y)\s+ago)\b/i;
+        
+        const processMessageContent = content => content
+            .replace(TimeDateRegex, x => getUnixTimestamp(x))
+            .replace(DateRegexTime, x => getUnixTimestamp(x))
+            .replace(timeRegex, x => getUnixTimestamp(x, "t"))
+            .replace(dateRegex, x => getUnixTimestamp(x, "d"))
+            .replace(relativeRegex, getRelativeTime);
+        
         Patcher.before(MessageActions, "sendMessage", (_, [, msg]) => {
-            const timeRegex = /(?<!\d)\d{1,2}:\d{2}(?!\d)(am|pm)?/gi;
-            timeRegexMatch = /((?<!\d)\d{1,2}:\d{2}(?!\d))(am|pm)?/i;
-
-            const dateFormat = Settings
-                .get("dateFormat", "dd.MM.yyyy")
-                .replace(/[.]/g, "[./]").replace("dd", "(\\d{2})")
-                .replace("MM", "(\\d{2})").replace("yyyy", "(\\d{4})");
-
-            const dateRegex = new RegExp(`${dateFormat}`, "gi");
-            dateRegexMatch = new RegExp(`${dateFormat}`, "i");
-
-            const TimeDateRegex = new RegExp(`(${timeRegex.source})\\s+${dateRegex.source}`, "gi");
-            const DateRegexTime = new RegExp(`${dateRegex.source}\\s+(${timeRegex.source})`, "gi");
-
-            const relativeRegex = /\b(?:in\s+(\d+)([smhdw]|mo|y)|(\d+)([smhdw]|mo|y)\s+ago)\b/gi;
-            relativeRegexMatch = /\b(?:in\s+(\d+)([smhdw]|mo|y)|(\d+)([smhdw]|mo|y)\s+ago)\b/i;
-
-            msg.content = msg.content
-                .replace(TimeDateRegex, x => getUnixTimestamp(x))
-                .replace(DateRegexTime, x => getUnixTimestamp(x))
-                .replace(timeRegex, x => getUnixTimestamp(x, "t"))
-                .replace(dateRegex, x => getUnixTimestamp(x, "d"))
-                .replace(relativeRegex, getRelativeTime);
+            msg.content = processMessageContent(msg.content);
+        });
+        
+        Patcher.before(MessageActions, "editMessage", (_, [channelId, messageId, msg]) => {
+            msg.content = processMessageContent(msg.content);
         });
     }
 

--- a/ReplaceTimestamps/modules/settings.json
+++ b/ReplaceTimestamps/modules/settings.json
@@ -31,5 +31,12 @@
             }
         ],
         "value": "dd.MM.yyyy"
+    },
+    {
+        "type": "switch",
+        "name": "Apply to Message Edits",
+        "note": "Whether to also convert timestamps when editing messages",
+        "id": "applyToEdits",
+        "value": true
     }
 ]

--- a/ReplaceTimestamps/package.json
+++ b/ReplaceTimestamps/package.json
@@ -1,20 +1,18 @@
 {
 	"name": "ReplaceTimestamps",
-	"version": "1.3.3",
-	"description": "Replaces plaintext times and dates into Discord's timestamps",
-	"author": "domi.btnr",
-	"authorId": "354191516979429376",
-	"invite": "gp2ExK5vc7",
-	"donate": "https://paypal.me/domibtnr",
-	"source": "https://github.com/domi-btnr/BetterDiscordStuff/tree/development/ReplaceTimestamps",
-	"changelog": [
-		{
-			"title": "Fixed",
-			"type": "fixed",
-			"items": [
-				"Plugin fixed for the latest Discord update"
-			]
-		}
-	],
-	"changelogDate": "2025-01-30"
+    "version": "1.4.0",
+    "description": "Replaces plaintext times and dates into Discord's timestamps",
+    "author": "domi.btnr",
+    "authorId": "354191516979429376",
+    "invite": "gp2ExK5vc7",
+    "donate": "https://paypal.me/domibtnr",
+    "source": "https://github.com/domi-btnr/BetterDiscordStuff/tree/development/ReplaceTimestamps",
+    "changelog": [{
+        "title": "Added",
+        "type": "added",
+        "items": [
+            "You now have the ability to Replace Timestamps when editing messages."
+        ]
+    }],
+    "changelogDate": "2025-02-26"
 }

--- a/ReplaceTimestamps/package.json
+++ b/ReplaceTimestamps/package.json
@@ -7,12 +7,14 @@
     "invite": "gp2ExK5vc7",
     "donate": "https://paypal.me/domibtnr",
     "source": "https://github.com/domi-btnr/BetterDiscordStuff/tree/development/ReplaceTimestamps",
-    "changelog": [{
-        "title": "Added",
-        "type": "added",
-        "items": [
-            "You now have the ability to Replace Timestamps when editing messages."
-        ]
-    }],
+    "changelog": [
+        {
+            "title": "Added",
+            "type": "added",
+            "items": [
+                "You now have the ability to Replace Timestamps when editing messages (Thanks to DaddyBoard)"
+            ]
+        }
+    ],
     "changelogDate": "2025-02-26"
 }


### PR DESCRIPTION
TODO For Domi:
- Add new setting option to disable Edit Message patcher
- Modify the `editMessage` patcher to only patch if option is on (aka handle setting logic within patcher logic)